### PR TITLE
Add team receipt management

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -20,6 +20,7 @@ import ImportTransactions from './pages/ImportTransactions';
 import Exports from './pages/Exports';
 import Profile from './pages/Profile';
 import CompanySettings from './pages/CompanySettings';
+import UserReceipts from './pages/UserReceipts';
 
 function App() {
   return (
@@ -45,6 +46,7 @@ function App() {
                     <Route path="/exports" element={<Exports />} />
                     <Route path="/profile" element={<Profile />} />
                     <Route path="/company-settings" element={<CompanySettings />} />
+                    <Route path="/team/:userId/receipts" element={<UserReceipts />} />
                   </Routes>
                 </main>
               </div>

--- a/frontend/src/pages/CompanySettings.js
+++ b/frontend/src/pages/CompanySettings.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import { Link } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { useAuth } from '../contexts/AuthContext';
 import { api } from '../services/api';
@@ -345,6 +346,7 @@ const CompanySettings = () => {
                     <th>Role</th>
                     <th>Joined</th>
                     <th>Last Login</th>
+                    <th>Receipts</th>
                     {currentCompany?.role === 'admin' && <th>Actions</th>}
                   </tr>
                 </thead>
@@ -379,6 +381,11 @@ const CompanySettings = () => {
                       </td>
                       <td>{formatDate(member.joinedAt)}</td>
                       <td>{formatDate(member.lastLogin)}</td>
+                      <td>
+                        <Link to={`/team/${member.id}/receipts`} className="btn btn-sm">
+                          View
+                        </Link>
+                      </td>
                       {currentCompany?.role === 'admin' && (
                         <td>
                           {member.id !== user.id && (

--- a/frontend/src/pages/UserReceipts.js
+++ b/frontend/src/pages/UserReceipts.js
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import { useAuth } from '../contexts/AuthContext';
+import { api } from '../services/api';
+
+const UserReceipts = () => {
+  const { userId } = useParams();
+  const { currentCompany } = useAuth();
+  const [receipts, setReceipts] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!currentCompany?.id) return;
+      setLoading(true);
+      try {
+        const res = await api.get(`/companies/${currentCompany.id}/users/${userId}/receipts`);
+        setReceipts(res.data.receipts || []);
+      } catch (err) {
+        console.error('Error loading user receipts:', err);
+        toast.error('Failed to load user receipts');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [userId, currentCompany]);
+
+  if (loading) {
+    return (
+      <div className="flex-center" style={{ height: '50vh' }}>
+        <div className="spinner"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="user-receipts-page">
+      <div className="page-header flex-between">
+        <h1>User Receipts</h1>
+        <Link to="/company-settings" className="btn btn-secondary">Back to Company</Link>
+      </div>
+
+      {receipts.length > 0 ? (
+        <div className="table-container">
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Filename</th>
+                <th>Upload Date</th>
+                <th>Extracted Amount</th>
+                <th>Merchant</th>
+                <th>Matches</th>
+              </tr>
+            </thead>
+            <tbody>
+              {receipts.map(r => (
+                <tr key={r.id}>
+                  <td>{r.original_filename}</td>
+                  <td>{new Date(r.upload_date).toLocaleDateString()}</td>
+                  <td>{r.extracted_amount ? `$${r.extracted_amount.toFixed(2)}` : '-'}</td>
+                  <td>{r.extracted_merchant || '-'}</td>
+                  <td>{r.match_count}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p>No receipts found for this user.</p>
+      )}
+    </div>
+  );
+};
+
+export default UserReceipts;


### PR DESCRIPTION
## Summary
- allow admins/managers to list receipts uploaded by a specific user
- show link in company settings team table to view a user's receipts
- add new `UserReceipts` page and route

## Testing
- `npm run build` *(frontend)*
- `npm install` *(backend)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68859a9f2964832bb0537001c988fda0