### PR TITLE
Document login rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,10 @@ Multiple extraction strategies in priority order:
 - `PUT /api/matches/:id` - Update match status
 - `DELETE /api/matches/:id` - Delete match
 
+## Login Rate Limit
+
+The authentication endpoints are rate limited in `backend/routes/auth.js`. Each IP may attempt to log in or register only five times every 15 minutes. If you hit this limit, wait for the window to reset or adjust the `authLimiter` values (`max` and `windowMs`) in that file.
+
 ## Contributing
 
 1. Fork the repository


### PR DESCRIPTION
## Summary
- document the login rate limit

## Testing
- `npm test` *(fails: Missing script)*
- `cd frontend && npm test -- --watchAll=false` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6885a2ade244832b8e60914b2e6e589a