### PR TITLE
Improve user receipts error handling

### DIFF
--- a/frontend/src/pages/UserReceipts.js
+++ b/frontend/src/pages/UserReceipts.js
@@ -19,7 +19,8 @@ const UserReceipts = () => {
         setReceipts(res.data.receipts || []);
       } catch (err) {
         console.error('Error loading user receipts:', err);
-        toast.error('Failed to load user receipts');
+        const message = err.response?.data?.error || 'Failed to load user receipts';
+        toast.error(message);
       } finally {
         setLoading(false);
       }


### PR DESCRIPTION
## Summary
- show server error message when loading team member receipts fails

## Testing
- `npm test` in `backend`
- `npm test -- -w 1` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6885ab4151fc832b8bfce763ca6b3d91